### PR TITLE
sql: improve auto partial stats job description

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -348,6 +348,9 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	if n.Name == jobspb.AutoStatsName {
 		// Use a user-friendly description for automatic statistics.
 		description = fmt.Sprintf("Table statistics refresh for %s", fqTableName)
+	} else if n.Name == jobspb.AutoPartialStatsName {
+		// Use a similar user-friendly description for partial statistics.
+		description = fmt.Sprintf("Partial statistics update for %s", fqTableName)
 	} else {
 		// This must be a user query, so use the statement (for consistency with
 		// other jobs triggered by statements).

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -244,29 +244,26 @@ func TestAutoPartialStatsJobDescription(t *testing.T) {
 
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
 
-	// Enable both automatic statistics collection and partial stats collection
-	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true;`)
-	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_partial_collection.enabled = true;`)
+	// Disable automatic statistics collection to prevent flakiness.
+	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_partial_collection.enabled = false;`)
 
 	// Create a test table.
 	sqlRunner.Exec(t, `CREATE TABLE test (id INT PRIMARY KEY, value INT);`)
 
-	// Insert more data to increase likelihood of triggering partial stats
-	sqlRunner.Exec(t, `INSERT INTO test SELECT i, i*100 FROM generate_series(1, 1000) AS g(i);`)
+	// Insert some data into the table.
+	sqlRunner.Exec(t, `INSERT INTO test SELECT i, i*100 FROM generate_series(1, 100) AS g(i);`)
 
-	// Explicitly trigger stats collection to avoid timing issues
-	sqlRunner.Exec(t, `ANALYZE test;`)
+	// Explicitly create partial stats to ensure we have a job to check.
+	sqlRunner.Exec(t, `CREATE STATISTICS __auto_partial__ FROM test`)
 
-	// Explicitly create partial stats to ensure we have a job to check
-	sqlRunner.Exec(t, `CREATE STATISTICS __auto_partial__ FROM test USING EXTREMES`)
-
-	// Wait for auto stats jobs to complete with a more flexible query
+	// Wait for the partial stats job to complete.
 	testutils.SucceedsSoon(t, func() error {
 		var count int
-		// Check for any auto stats jobs related to our table
+		// Check specifically for AUTO CREATE PARTIAL STATS jobs related to our table.
 		sqlRunner.QueryRow(t, `
 			SELECT count(*) FROM system.jobs 
-			WHERE (job_type = 'AUTO CREATE STATS' OR job_type = 'AUTO CREATE PARTIAL STATS') 
+			WHERE job_type = 'AUTO CREATE PARTIAL STATS' 
 			AND description LIKE '%test%'`).Scan(&count)
 		if count == 0 {
 			return errors.New("expected at least one AUTO CREATE PARTIAL STATS job")
@@ -274,11 +271,11 @@ func TestAutoPartialStatsJobDescription(t *testing.T) {
 		return nil
 	})
 
-	// Verify job description with a more flexible query
+	// Verify job description contains the expected text.
 	var description string
 	sqlRunner.QueryRow(t, `
 		SELECT description FROM system.jobs 
-		WHERE (job_type = 'AUTO CREATE STATS' OR job_type = 'AUTO CREATE PARTIAL STATS')
+		WHERE job_type = 'AUTO CREATE PARTIAL STATS'
 		AND description LIKE '%test%' 
 		LIMIT 1`).Scan(&description)
 

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -8,6 +8,7 @@ package sql_test
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // TestStatsWithLowTTL simulates a CREATE STATISTICS run that takes longer than
@@ -229,5 +231,44 @@ func BenchmarkAnalyze(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sqlRunner.Exec(b, `ANALYZE t`)
+	}
+}
+
+func TestAutoPartialStatsJobDescription(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Enable automatic statistics collection.
+	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true;`)
+
+	// Create a test table.
+	sqlRunner.Exec(t, `CREATE TABLE test (id INT PRIMARY KEY, value INT);`)
+
+	// Insert data to trigger auto stats collection.
+	sqlRunner.Exec(t, `INSERT INTO test VALUES (1, 100), (2, 200), (3, 300);`)
+
+	// Wait for auto stats jobs to complete.
+	testutils.SucceedsSoon(t, func() error {
+		var count int
+		sqlRunner.QueryRow(t, `SELECT count(*) FROM system.jobs WHERE job_type = 'AUTO CREATE PARTIAL STATS'`).Scan(&count)
+		if count == 0 {
+			return errors.New("expected at least one AUTO CREATE PARTIAL STATS job")
+		}
+		return nil
+	})
+
+	// Verify job description.
+	var description string
+	sqlRunner.QueryRow(t, `SELECT description FROM system.jobs WHERE job_type = 'AUTO CREATE PARTIAL STATS'`).Scan(&description)
+
+	expectedDescription := "Partial statistics update for test"
+	if !strings.Contains(description, expectedDescription) {
+		t.Errorf("expected description to contain: %s, got: %s", expectedDescription, description)
 	}
 }

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -244,30 +244,45 @@ func TestAutoPartialStatsJobDescription(t *testing.T) {
 
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
 
-	// Enable automatic statistics collection.
+	// Enable both automatic statistics collection and partial stats collection
 	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true;`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_partial_collection.enabled = true;`)
 
 	// Create a test table.
 	sqlRunner.Exec(t, `CREATE TABLE test (id INT PRIMARY KEY, value INT);`)
 
-	// Insert data to trigger auto stats collection.
-	sqlRunner.Exec(t, `INSERT INTO test VALUES (1, 100), (2, 200), (3, 300);`)
+	// Insert more data to increase likelihood of triggering partial stats
+	sqlRunner.Exec(t, `INSERT INTO test SELECT i, i*100 FROM generate_series(1, 1000) AS g(i);`)
 
-	// Wait for auto stats jobs to complete.
+	// Explicitly trigger stats collection to avoid timing issues
+	sqlRunner.Exec(t, `ANALYZE test;`)
+
+	// Explicitly create partial stats to ensure we have a job to check
+	sqlRunner.Exec(t, `CREATE STATISTICS __auto_partial__ FROM test USING EXTREMES`)
+
+	// Wait for auto stats jobs to complete with a more flexible query
 	testutils.SucceedsSoon(t, func() error {
 		var count int
-		sqlRunner.QueryRow(t, `SELECT count(*) FROM system.jobs WHERE job_type = 'AUTO CREATE PARTIAL STATS'`).Scan(&count)
+		// Check for any auto stats jobs related to our table
+		sqlRunner.QueryRow(t, `
+			SELECT count(*) FROM system.jobs 
+			WHERE (job_type = 'AUTO CREATE STATS' OR job_type = 'AUTO CREATE PARTIAL STATS') 
+			AND description LIKE '%test%'`).Scan(&count)
 		if count == 0 {
 			return errors.New("expected at least one AUTO CREATE PARTIAL STATS job")
 		}
 		return nil
 	})
 
-	// Verify job description.
+	// Verify job description with a more flexible query
 	var description string
-	sqlRunner.QueryRow(t, `SELECT description FROM system.jobs WHERE job_type = 'AUTO CREATE PARTIAL STATS'`).Scan(&description)
+	sqlRunner.QueryRow(t, `
+		SELECT description FROM system.jobs 
+		WHERE (job_type = 'AUTO CREATE STATS' OR job_type = 'AUTO CREATE PARTIAL STATS')
+		AND description LIKE '%test%' 
+		LIMIT 1`).Scan(&description)
 
-	expectedDescription := "Partial statistics update for test"
+	expectedDescription := "Partial statistics update for"
 	if !strings.Contains(description, expectedDescription) {
 		t.Errorf("expected description to contain: %s, got: %s", expectedDescription, description)
 	}


### PR DESCRIPTION
Previously, the job description for AUTO CREATE PARTIAL STATS defaulted to a raw SQL description, making it harder to read and difficult to distinguish these jobs in system.jobs.

This was inadequate because users need clear job descriptions to differentiate between full and partial automatic statistics updates, especially for debugging or monitoring job execution.

To address this, this patch updates the job description to include plain English and explicitly indicate that the job is for automatic partial statistics collection, improving clarity in system.jobs.

Fixes #140054.

Release note (sql change): The job description for AUTO CREATE PARTIAL STATS now clearly indicates its purpose in plain English, improving system.jobs visibility and debugging.